### PR TITLE
Remove redundant priority assignment in PCB initialization

### DIFF
--- a/process/pcb.py
+++ b/process/pcb.py
@@ -18,9 +18,8 @@ class PCB:
         # 进程状态信息
         self.state = "new"
         self.cpu_state = {}  # CPU寄存器状态
-        
+
         # 进程调度信息
-        self.priority = priority
         self.scheduling_info = {
             'arrival_time': time.time(),
             'burst_time': 0,


### PR DESCRIPTION
## Summary
- Ensure PCB constructor only sets priority once by removing duplicate assignment

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890619479ac8331b162dd5356dc5fbf