### PR TITLE
Fix logging initialization and tidy modules

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,32 +19,23 @@ from utils.boot_animation import BootAnimation, show_startup_sequence, show_welc
 
 def main():
     """主程序入口"""
-    # 创建启动动画
+    logger = Logger()
     boot_anim = BootAnimation()
-    
+
     try:
-        # 显示启动界面
         boot_anim.show_boot_screen()
-        
-        # 显示启动序列
         show_startup_sequence()
-        
-        # 初始化日志系统
-        logger = Logger()
         logger.info("PyOS系统启动中...")
-        
-        # 创建并启动系统
+
         system = System()
         system.boot()
-        
-        # 显示欢迎信息
+
         show_welcome_message()
-        
-        # 启动Shell
+
         from shell.shell import Shell
         shell = Shell(system)
         shell.run()
-        
+
     except KeyboardInterrupt:
         print(f"\n{Fore.YELLOW}系统被用户中断{Style.RESET_ALL}")
         logger.info("系统被用户中断")
@@ -56,4 +47,4 @@ def main():
         logger.info("PyOS系统关闭")
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/shell/shell.py
+++ b/shell/shell.py
@@ -3,8 +3,8 @@ Shell核心模块 - 实现命令行界面
 """
 
 import threading
-from typing import List, Optional, Dict, Any
-from colorama import Fore, Back, Style
+from typing import List, Optional, Dict
+from colorama import Fore, Style
 
 import readline
 import inspect
@@ -94,7 +94,6 @@ class Shell:
         else:
             cmd = tokens[0]
             cur_arg = tokens[-1] if not buffer.endswith(' ') else ''
-            prev_args = tokens[1:-1] if not buffer.endswith(' ') else tokens[1:]
             # 参数补全
             if cur_arg.startswith('-'):
                 options = [p for p in self._get_param_list(cmd) if p.startswith(cur_arg)]
@@ -375,4 +374,4 @@ class Shell:
         print("  tree -d 2       - 显示深度为2的目录树")
         print("  cd /home/user   - 切换到用户目录")
         print()
-        print(f"{Fore.YELLOW}注意: 这是一个虚拟文件系统，与真实文件系统隔离{Style.RESET_ALL}") 
+        print(f"{Fore.YELLOW}注意: 这是一个虚拟文件系统，与真实文件系统隔离{Style.RESET_ALL}")

--- a/utils/boot_animation.py
+++ b/utils/boot_animation.py
@@ -6,7 +6,7 @@ import sys
 import os
 import time
 import threading
-from colorama import Fore, Back, Style
+from colorama import Fore, Style
 
 class BootAnimation:
     """启动动画类"""
@@ -67,7 +67,7 @@ class BootAnimation:
 ║  {Fore.WHITE}操作系统: {Fore.CYAN}PyOS 1.0.0{Fore.GREEN}                              ║
 ║  {Fore.WHITE}Python版本: {Fore.CYAN}{sys.version.split()[0]}{Fore.GREEN}                    ║
 ║  {Fore.WHITE}平台: {Fore.CYAN}{sys.platform}{Fore.GREEN}                              ║
-║  {Fore.WHITE}架构: {Fore.CYAN}{sys.maxsize > 2**32 and '64-bit' or '32-bit'}{Fore.GREEN}                    ║
+    ║  {Fore.WHITE}架构: {Fore.CYAN}{'64-bit' if sys.maxsize > 2**32 else '32-bit'}{Fore.GREEN}                    ║
 ║  {Fore.WHITE}启动时间: {Fore.CYAN}{time.strftime('%Y-%m-%d %H:%M:%S')}{Fore.GREEN}              ║
 ╚══════════════════════════════════════════════════════════════╝{Style.RESET_ALL}
 """
@@ -119,4 +119,4 @@ def show_welcome_message():
     """显示欢迎信息"""
     print(f"\n{Fore.CYAN}{'='*60}")
     print(f"{Fore.CYAN}    🎉 欢迎使用 PyOS 操作系统! 🎉")
-    print(f"{Fore.CYAN}{'='*60}{Style.RESET_ALL}") 
+    print(f"{Fore.CYAN}{'='*60}{Style.RESET_ALL}")

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -4,7 +4,6 @@
 
 import logging
 import os
-import time
 import threading
 from datetime import datetime
 from typing import Optional
@@ -69,7 +68,7 @@ class Logger:
                 self.logger.addHandler(file_handler)
                 self._handlers_initialized = True
                 
-            except Exception as e:
+            except Exception:
                 # 如果文件处理器设置失败，只使用控制台
                 pass
     
@@ -107,6 +106,7 @@ class Logger:
         if details:
             message += f" - {details}"
         self.info(message)
+
     
     def log_process_event(self, pid: int, event: str, details: Optional[str] = None):
         """记录进程事件"""
@@ -130,4 +130,4 @@ class Logger:
         
         # 对于文件系统事件，确保文件处理器已初始化
         self._ensure_file_handler()
-        self.info(message) 
+        self.info(message)


### PR DESCRIPTION
## Summary
- create Logger before try block to avoid unbound references
- remove unused imports and variables throughout shell and utils modules
- simplify boot animation architecture check and clean up formatting

## Testing
- `python -m compileall -q .`
- `python main.py >/tmp/main.log 2>&1` *(stopped for interactive input; log inspected)*

------
https://chatgpt.com/codex/tasks/task_e_6890aad202c88331b62442ac51dbef13